### PR TITLE
Feat/step2: 친구에게 송금 API 추가

### DIFF
--- a/src/main/java/com/jindo/minipay/account/checking/controller/CheckingAccountController.java
+++ b/src/main/java/com/jindo/minipay/account/checking/controller/CheckingAccountController.java
@@ -1,6 +1,9 @@
 package com.jindo.minipay.account.checking.controller;
 
 import com.jindo.minipay.account.checking.dto.CheckingAccountChargeRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountChargeResponse;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireResponse;
 import com.jindo.minipay.account.checking.service.CheckingAccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +21,14 @@ public class CheckingAccountController {
   private final CheckingAccountService checkingAccountService;
 
   @PostMapping("/charge")
-  public ResponseEntity<Void> charge(@RequestBody @Valid CheckingAccountChargeRequest request) {
-    checkingAccountService.charge(request);
-    return ResponseEntity.ok().build();
+  public ResponseEntity<CheckingAccountChargeResponse> charge(
+      @RequestBody @Valid CheckingAccountChargeRequest request) {
+    return ResponseEntity.ok().body(checkingAccountService.charge(request));
+  }
+
+  @PostMapping("/wire")
+  public ResponseEntity<CheckingAccountWireResponse> wire(
+      @RequestBody @Valid CheckingAccountWireRequest request) {
+    return ResponseEntity.ok().body(checkingAccountService.wire(request));
   }
 }

--- a/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountChargeResponse.java
+++ b/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountChargeResponse.java
@@ -1,0 +1,14 @@
+package com.jindo.minipay.account.checking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckingAccountChargeResponse {
+
+  private long balance;
+
+}

--- a/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountWireRequest.java
+++ b/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountWireRequest.java
@@ -1,0 +1,22 @@
+package com.jindo.minipay.account.checking.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckingAccountWireRequest {
+
+  @NotNull
+  private Long senderId;
+
+  @NotNull
+  private Long receiverId;
+
+  @Min(1L)
+  private long amount;
+}

--- a/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountWireResponse.java
+++ b/src/main/java/com/jindo/minipay/account/checking/dto/CheckingAccountWireResponse.java
@@ -1,0 +1,14 @@
+package com.jindo.minipay.account.checking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckingAccountWireResponse {
+
+  private long balance;
+
+}

--- a/src/main/java/com/jindo/minipay/account/checking/entity/CheckingAccount.java
+++ b/src/main/java/com/jindo/minipay/account/checking/entity/CheckingAccount.java
@@ -1,6 +1,9 @@
 package com.jindo.minipay.account.checking.entity;
 
+import static com.jindo.minipay.global.exception.ErrorCode.*;
+
 import com.jindo.minipay.global.entity.BaseTimeEntity;
+import com.jindo.minipay.global.exception.CustomException;
 import com.jindo.minipay.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,11 +38,14 @@ public class CheckingAccount extends BaseTimeEntity {
   @JoinColumn(nullable = false)
   private Member owner;
 
-  public void charge(long amount) {
+  public void deposit(long amount) {
     balance += amount;
   }
 
   public void withdraw(long amount) {
+    if (balance < amount) {
+      throw new CustomException(BALANCE_NOT_ENOUGH);
+    }
     this.balance -= amount;
   }
 }

--- a/src/main/java/com/jindo/minipay/account/checking/service/CheckingAccountService.java
+++ b/src/main/java/com/jindo/minipay/account/checking/service/CheckingAccountService.java
@@ -1,20 +1,23 @@
 package com.jindo.minipay.account.checking.service;
 
 import static com.jindo.minipay.account.common.constant.AccountConstants.ACCOUNT_CHARGE_LIMIT;
+import static com.jindo.minipay.account.common.constant.AccountConstants.AUTO_CHARGE_UNIT;
 import static com.jindo.minipay.global.exception.ErrorCode.ACCOUNT_NOT_FOUND;
 import static com.jindo.minipay.global.exception.ErrorCode.CHARGE_LIMIT_EXCEEDED;
 
 import com.jindo.minipay.account.checking.dto.CheckingAccountChargeRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountChargeResponse;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireResponse;
 import com.jindo.minipay.account.checking.entity.ChargeAmount;
 import com.jindo.minipay.account.checking.entity.CheckingAccount;
-import com.jindo.minipay.account.checking.repository.redis.ChargeAmountRepository;
 import com.jindo.minipay.account.checking.repository.CheckingAccountRepository;
+import com.jindo.minipay.account.checking.repository.redis.ChargeAmountRepository;
 import com.jindo.minipay.global.exception.CustomException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -25,26 +28,83 @@ public class CheckingAccountService {
 
   private final ChargeAmountRepository chargeAmountRepository;
 
-  @Transactional(isolation = Isolation.READ_COMMITTED)
-  public void charge(CheckingAccountChargeRequest request) {
-    CheckingAccount checkingAccount = checkingAccountRepository
-        .findByOwnerIdForUpdate(request.getMemberId())
-        .orElseThrow(() -> new CustomException(ACCOUNT_NOT_FOUND));
+  @Transactional
+  public CheckingAccountChargeResponse charge(CheckingAccountChargeRequest request) {
+    CheckingAccount checkingAccount = getCheckingAccountForUpdate(request.getMemberId());
 
-    long chargeAmount = chargeAmountRepository.findByMemberId(request.getMemberId())
-        .orElseGet(() -> new ChargeAmount(request.getMemberId(), 0L)).getAmount();
+    actualCharge(checkingAccount, request.getAmount());
 
-    long afterChargeAmount = chargeAmount + request.getAmount();
-    chargeLimitValidation(afterChargeAmount);
-
-    chargeAmountRepository.save(request.getMemberId(), afterChargeAmount, timeToMidnight());
-
-    checkingAccount.charge(request.getAmount());
+    return new CheckingAccountChargeResponse(checkingAccount.getBalance());
   }
 
-  private void chargeLimitValidation(long afterChargeAmount) {
+  @Transactional
+  public CheckingAccountWireResponse wire(CheckingAccountWireRequest request) {
+
+    // TODO: 데드락 해결하기
+    Long senderId = request.getSenderId();
+    Long receiverId = request.getReceiverId();
+
+    CheckingAccount senderAccount;
+    CheckingAccount receiverAccount;
+
+    if (senderId < receiverId) {
+      senderAccount = getCheckingAccountForUpdate(senderId);
+      receiverAccount = getCheckingAccountForUpdate(receiverId);
+    } else {
+      receiverAccount = getCheckingAccountForUpdate(receiverId);
+      senderAccount = getCheckingAccountForUpdate(senderId);
+    }
+
+    checkBalanceAndAutoCharge(senderAccount, request.getAmount());
+
+    senderAccount.withdraw(request.getAmount());
+
+    receiverAccount.deposit(request.getAmount());
+
+    return new CheckingAccountWireResponse(senderAccount.getBalance());
+  }
+
+  private CheckingAccount getCheckingAccountForUpdate(Long memberId) {
+    return checkingAccountRepository
+        .findByOwnerIdForUpdate(memberId)
+        .orElseThrow(() -> new CustomException(ACCOUNT_NOT_FOUND));
+  }
+
+  private void actualCharge(CheckingAccount checkingAccount, long amount) {
+    updateChargeAmountOfMember(checkingAccount.getOwner().getId(), amount);
+    checkingAccount.deposit(amount);
+  }
+
+  private void updateChargeAmountOfMember(Long memberId, long amount) {
+    long chargeAmount = getChargeAmountOfMember(memberId).getAmount();
+
+    long afterChargeAmount = chargeAmount + amount;
+    validateChargeLimit(afterChargeAmount);
+
+    chargeAmountRepository.save(memberId, afterChargeAmount, timeToMidnight());
+  }
+
+  private ChargeAmount getChargeAmountOfMember(Long memberId) {
+    return chargeAmountRepository.findByMemberId(memberId)
+        .orElseGet(() -> new ChargeAmount(memberId, 0L));
+  }
+
+  private void validateChargeLimit(long afterChargeAmount) {
     if (afterChargeAmount > ACCOUNT_CHARGE_LIMIT) {
       throw new CustomException(CHARGE_LIMIT_EXCEEDED);
+    }
+  }
+
+  private void checkBalanceAndAutoCharge(CheckingAccount checkingAccount, long amount) {
+    long balance = checkingAccount.getBalance();
+    if (balance < amount) {
+      long diff = amount - balance;
+      long chargeAmount = (diff / AUTO_CHARGE_UNIT) * AUTO_CHARGE_UNIT;
+
+      if (diff % ACCOUNT_CHARGE_LIMIT > 0) {
+        chargeAmount += AUTO_CHARGE_UNIT;
+      }
+      actualCharge(checkingAccount, chargeAmount);
     }
   }
 

--- a/src/main/java/com/jindo/minipay/account/common/constant/AccountConstants.java
+++ b/src/main/java/com/jindo/minipay/account/common/constant/AccountConstants.java
@@ -6,7 +6,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccountConstants {
 
-  public static final int ACCOUNT_CHARGE_LIMIT = 3_000_000;
+  public static final long ACCOUNT_CHARGE_LIMIT = 3_000_000L;
+
+  public static final long AUTO_CHARGE_UNIT = 10_000L;
 
   public static final String CHARGE_AMOUNT_KEY = "chargeAmount:";
 }

--- a/src/test/java/com/jindo/minipay/account/checking/controller/CheckingAccountControllerTest.java
+++ b/src/test/java/com/jindo/minipay/account/checking/controller/CheckingAccountControllerTest.java
@@ -1,11 +1,16 @@
 package com.jindo.minipay.account.checking.controller;
 
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jindo.minipay.account.checking.dto.CheckingAccountChargeRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountChargeResponse;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireResponse;
 import com.jindo.minipay.account.checking.service.CheckingAccountService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -41,7 +46,6 @@ class CheckingAccountControllerTest {
       CheckingAccountChargeRequest request = new CheckingAccountChargeRequest(null, 10_000L);
 
       // when
-      doNothing().when(checkingAccountService).charge(request);
       // then
       mockMvc.perform(post(URI + "/charge")
               .contentType(MediaType.APPLICATION_JSON)
@@ -51,12 +55,11 @@ class CheckingAccountControllerTest {
 
     @Test
     @DisplayName("실패 - 충전금액이 음수 값인 경우")
-    void charge_null_amount() throws Exception {
+    void charge_negative_amount() throws Exception {
       // given
       CheckingAccountChargeRequest request = new CheckingAccountChargeRequest(1L, -10_000L);
 
       // when
-      doNothing().when(checkingAccountService).charge(request);
       // then
       mockMvc.perform(post(URI + "/charge")
               .contentType(MediaType.APPLICATION_JSON)
@@ -69,14 +72,96 @@ class CheckingAccountControllerTest {
     void charge() throws Exception {
       // given
       CheckingAccountChargeRequest request = new CheckingAccountChargeRequest(1L, 10_000L);
+      CheckingAccountChargeResponse response = new CheckingAccountChargeResponse(10_000L);
+
+      when(checkingAccountService.charge(any())).thenReturn(response);
 
       // when
-      doNothing().when(checkingAccountService).charge(request);
       // then
       mockMvc.perform(post(URI + "/charge")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isOk());
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.balance").value(10_000L));
+    }
+  }
+
+  @Nested
+  @DisplayName("친구에게 송금")
+  class CheckingAccountWireMethod {
+
+    @Test
+    @DisplayName("실패 - 송신자 아이디가 null 값인 경우")
+    void wire_null_senderId() throws Exception {
+      // given
+      CheckingAccountWireRequest request = new CheckingAccountWireRequest(null, 1L, 10_000L);
+
+      // when
+      // then
+      mockMvc.perform(post(URI + "/wire")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("실패 - 수신자 아이디가 null 값인 경우")
+    void wire_null_receiverId() throws Exception {
+      // given
+      CheckingAccountWireRequest request = new CheckingAccountWireRequest(1L, null, 10_000L);
+
+      // when
+      // then
+      mockMvc.perform(post(URI + "/wire")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("실패 - 송금금액이 0인 경우")
+    void wire_zero_amount() throws Exception {
+      // given
+      CheckingAccountWireRequest request = new CheckingAccountWireRequest(1L, 1L, 0);
+
+      // when
+      // then
+      mockMvc.perform(post(URI + "/wire")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("실패 - 송금금액이 음수 값인 경우")
+    void wire_negative_amount() throws Exception {
+      // given
+      CheckingAccountWireRequest request = new CheckingAccountWireRequest(1L, 1L, -10_000L);
+
+      // when
+      // then
+      mockMvc.perform(post(URI + "/wire")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("성공")
+    void wire() throws Exception {
+      // given
+      CheckingAccountWireRequest request = new CheckingAccountWireRequest(1L, 1L, 10_000L);
+      CheckingAccountWireResponse response = new CheckingAccountWireResponse(10_000L);
+
+      when(checkingAccountService.wire(any())).thenReturn(response);
+
+      // when
+      // then
+      mockMvc.perform(post(URI + "/wire")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.balance").value(10_000L));
     }
   }
 }

--- a/src/test/java/com/jindo/minipay/account/checking/service/CheckingAccountServiceTest.java
+++ b/src/test/java/com/jindo/minipay/account/checking/service/CheckingAccountServiceTest.java
@@ -1,21 +1,26 @@
 package com.jindo.minipay.account.checking.service;
 
 import static com.jindo.minipay.account.common.constant.AccountConstants.ACCOUNT_CHARGE_LIMIT;
+import static com.jindo.minipay.global.exception.ErrorCode.ACCOUNT_NOT_FOUND;
+import static com.jindo.minipay.global.exception.ErrorCode.CHARGE_LIMIT_EXCEEDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jindo.minipay.account.checking.dto.CheckingAccountChargeRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountChargeResponse;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireResponse;
 import com.jindo.minipay.account.checking.entity.ChargeAmount;
 import com.jindo.minipay.account.checking.entity.CheckingAccount;
-import com.jindo.minipay.account.checking.repository.redis.ChargeAmountRepository;
 import com.jindo.minipay.account.checking.repository.CheckingAccountRepository;
+import com.jindo.minipay.account.checking.repository.redis.ChargeAmountRepository;
 import com.jindo.minipay.global.exception.CustomException;
-import com.jindo.minipay.global.exception.ErrorCode;
 import com.jindo.minipay.member.entity.Member;
 import java.time.Duration;
 import java.util.Optional;
@@ -43,7 +48,9 @@ class CheckingAccountServiceTest {
   @DisplayName("메인 계좌 충전")
   class CheckingAccountChargeMethod {
 
-    CheckingAccountChargeRequest request = new CheckingAccountChargeRequest(1L, 10_000L);
+    long amount = 10_000L;
+
+    CheckingAccountChargeRequest request = new CheckingAccountChargeRequest(1L, amount);
 
     Member owner = Member.builder()
         .id(request.getMemberId())
@@ -61,32 +68,32 @@ class CheckingAccountServiceTest {
     void charge_not_found_checking_account() {
       // given
       given(checkingAccountRepository.findByOwnerIdForUpdate(request.getMemberId()))
-          .willThrow(new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+          .willThrow(new CustomException(ACCOUNT_NOT_FOUND));
 
       // when
       // then
       assertThatThrownBy(() -> checkingAccountService.charge(request))
           .isInstanceOf(CustomException.class)
-          .hasMessage(ErrorCode.ACCOUNT_NOT_FOUND.getMessage());
+          .hasMessage(ACCOUNT_NOT_FOUND.getMessage());
     }
 
     @Test
     @DisplayName("실패 - 일일 충전 한도를 초과했을 때")
     void charge_limit_exceeded() {
       // given
-      ChargeAmount exceedAmount = new ChargeAmount(owner.getId(), ACCOUNT_CHARGE_LIMIT);
+      ChargeAmount limitMaximumAmount = new ChargeAmount(owner.getId(), ACCOUNT_CHARGE_LIMIT);
 
       when(checkingAccountRepository.findByOwnerIdForUpdate(request.getMemberId())).thenReturn(
           Optional.of(checkingAccount));
 
       when(chargeAmountRepository.findByMemberId(request.getMemberId())).thenReturn(
-          Optional.of(exceedAmount));
+          Optional.of(limitMaximumAmount));
 
       // when
       // then
       assertThatThrownBy(() -> checkingAccountService.charge(request))
           .isInstanceOf(CustomException.class)
-          .hasMessage(ErrorCode.CHARGE_LIMIT_EXCEEDED.getMessage());
+          .hasMessage(CHARGE_LIMIT_EXCEEDED.getMessage());
     }
 
     @Test
@@ -102,12 +109,137 @@ class CheckingAccountServiceTest {
           Optional.of(chargeAmount));
 
       // when
-      checkingAccountService.charge(request);
+      CheckingAccountChargeResponse response = checkingAccountService.charge(request);
 
       // then
       verify(chargeAmountRepository, times(1)).save(any(Long.class), any(Long.class),
           any(Duration.class));
-      assertThat(checkingAccount.getBalance()).isEqualTo(20_000L);
+      assertThat(response.getBalance()).isEqualTo(20_000L);
+    }
+  }
+
+  @Nested
+  @DisplayName("계좌 송금")
+  class CheckingAccountWireMethod {
+
+    long amount = 15_000L;
+
+    CheckingAccountWireRequest request = new CheckingAccountWireRequest(1L, 2L, amount);
+
+    @Test
+    @DisplayName("실패 - 송신자의 메인계좌가 없는 경우")
+    void wire_not_found_sender_checking_account() {
+      // given
+      given(checkingAccountRepository.findByOwnerIdForUpdate(request.getSenderId()))
+          .willThrow(new CustomException(ACCOUNT_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> checkingAccountService.wire(request))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(ACCOUNT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패 - 수신자의 메인계좌가 없는 경우")
+    void wire_not_found_receiver_checking_account() {
+      // given
+      Member sender = Member.builder()
+          .id(1L)
+          .build();
+
+      CheckingAccount senderAccount = CheckingAccount.builder()
+          .id(1L)
+          .owner(sender)
+          .accountNumber("111112345678")
+          .build();
+
+      given(checkingAccountRepository.findByOwnerIdForUpdate(request.getSenderId()))
+          .willReturn(Optional.of(senderAccount));
+
+      given(checkingAccountRepository.findByOwnerIdForUpdate(request.getReceiverId()))
+          .willThrow(new CustomException(ACCOUNT_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> checkingAccountService.wire(request))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(ACCOUNT_NOT_FOUND.getMessage());
+    }
+
+    @Nested
+    @DisplayName("송신자의 잔액이 송금 금액보다 적은 경우 - 자동 충전")
+    class isBalanceLessThanWireAmount {
+
+      Member sender = Member.builder()
+          .id(1L)
+          .build();
+
+      CheckingAccount senderAccount = CheckingAccount.builder()
+          .id(1L)
+          .owner(sender)
+          .accountNumber("111112345678")
+          .balance(0L)
+          .build();
+
+      Member receiver = Member.builder()
+          .id(2L)
+          .build();
+
+      CheckingAccount receiverAccount = CheckingAccount.builder()
+          .id(2L)
+          .owner(receiver)
+          .accountNumber("111198765432")
+          .balance(0L)
+          .build();
+
+      @Test
+      @DisplayName("실패 - 송신자의 일일 한도가 초과한 경우")
+      void wire_limit_exceeded() {
+        // given
+        ChargeAmount limitMaximumAmount = new ChargeAmount(sender.getId(), ACCOUNT_CHARGE_LIMIT);
+
+        when(checkingAccountRepository.findByOwnerIdForUpdate(request.getSenderId())).thenReturn(
+            Optional.of(senderAccount));
+
+        when(checkingAccountRepository.findByOwnerIdForUpdate(request.getReceiverId())).thenReturn(
+            Optional.of(receiverAccount));
+
+        when(chargeAmountRepository.findByMemberId(request.getSenderId())).thenReturn(
+            Optional.of(limitMaximumAmount));
+        // when
+        // then
+        assertThatThrownBy(() -> checkingAccountService.wire(request))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(CHARGE_LIMIT_EXCEEDED.getMessage());
+      }
+
+      @Test
+      @DisplayName("성공 - 송신자의 계좌에 자동 충전 단위로 충전된 후 수신자의 계좌에 송금한다.")
+      void wire_autoCharge() {
+        // given
+        ChargeAmount chargeAmount = new ChargeAmount(sender.getId(), 0L);
+
+        when(checkingAccountRepository.findByOwnerIdForUpdate(request.getSenderId())).thenReturn(
+            Optional.of(senderAccount));
+
+        when(checkingAccountRepository.findByOwnerIdForUpdate(request.getReceiverId())).thenReturn(
+            Optional.of(receiverAccount));
+
+        when(chargeAmountRepository.findByMemberId(request.getSenderId())).thenReturn(
+            Optional.of(chargeAmount));
+
+        // when
+        CheckingAccountWireResponse response = checkingAccountService.wire(request);
+
+        // then
+        verify(chargeAmountRepository, times(1)).save(any(Long.class), anyLong(),
+            any(Duration.class));
+
+        assertThat(receiverAccount.getBalance()).isEqualTo(15_000L);
+
+        assertThat(response.getBalance()).isEqualTo(5_000L);
+      }
     }
   }
 }

--- a/src/test/java/com/jindo/minipay/account/concurrent/AccountConcurrentTest.java
+++ b/src/test/java/com/jindo/minipay/account/concurrent/AccountConcurrentTest.java
@@ -3,6 +3,7 @@ package com.jindo.minipay.account.concurrent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jindo.minipay.account.checking.dto.CheckingAccountChargeRequest;
+import com.jindo.minipay.account.checking.dto.CheckingAccountWireRequest;
 import com.jindo.minipay.account.checking.entity.CheckingAccount;
 import com.jindo.minipay.account.checking.repository.CheckingAccountRepository;
 import com.jindo.minipay.account.checking.service.CheckingAccountService;
@@ -46,34 +47,61 @@ public class AccountConcurrentTest {
   CheckingAccountRepository checkingAccountRepository;
 
   @Test
-  @DisplayName("메인계좌 충전, 적금계좌 입금 동시성 테스트")
-  void concurrent_charge_deposit() throws InterruptedException {
+  @DisplayName("메인계좌 충전, 적금계좌 입금, 친구에게 송금 동시성 테스트")
+  void checking_account_concurrent() throws InterruptedException {
     // given
 
     // 회원등록
-    String username = "concurrentTestUser";
-    memberService.signup(new MemberSignupRequest(username, "1q2w3e4r!"));
-    Member owner = memberRepository.findByUsername(username).get();
+    String loginUsername = "loginUsername";
+    memberService.signup(new MemberSignupRequest(loginUsername, "1q2w3e4r!"));
+    Member loginUser = memberRepository.findByUsername(loginUsername).get();
 
-    // 메인 계좌 개설 및 충전
-    CheckingAccount savedCheckingAccount = checkingAccountRepository.findByOwnerId(owner.getId())
-        .get();
-    checkingAccountService.charge(new CheckingAccountChargeRequest(owner.getId(), 100_000L));
+    // 친구등록
+    String friendUsername = "friendUsername";
+    memberService.signup(new MemberSignupRequest(friendUsername, "1q2w3e4r!"));
+    Member friend = memberRepository.findByUsername(friendUsername).get();
+
+    // 메인 계좌 충전
+    checkingAccountService.charge(new CheckingAccountChargeRequest(loginUser.getId(), 1_000_000L));
+
+    checkingAccountService.charge(new CheckingAccountChargeRequest(friend.getId(), 1_000_000L));
 
     // 적금 계좌 개설
-    SavingAccountCreateResponse savingAccountCreateResponse = savingAccountService.create(
-        new SavingAccountCreateRequest(owner.getId()));
+    SavingAccountCreateResponse loginUserSavingAccountCreateResponse = savingAccountService.create(
+        new SavingAccountCreateRequest(loginUser.getId()));
 
-    // 메인 계좌 충전 request
-    CheckingAccountChargeRequest chargeRequest =
-        new CheckingAccountChargeRequest(owner.getId(), 10_000L);
+    SavingAccountCreateResponse friendSavingAccountCreateResponse = savingAccountService.create(
+        new SavingAccountCreateRequest(friend.getId()));
 
-    // 적금 계좌 충전 request
-    SavingAccountDepositRequest depositRequest =
-        new SavingAccountDepositRequest(owner.getId(), savingAccountCreateResponse.getSavingAccountId(),
+    // 로그인 유저 메인 계좌 충전 request
+    CheckingAccountChargeRequest loginUserChargeRequest =
+        new CheckingAccountChargeRequest(loginUser.getId(), 10_000L);
+
+    // 친구 메인 계좌 충전 request
+    CheckingAccountChargeRequest friendChargeRequest =
+        new CheckingAccountChargeRequest(friend.getId(), 10_000L);
+
+    // 로그인 유저 적금 계좌 입금 request
+    SavingAccountDepositRequest loginUserDepositRequest =
+        new SavingAccountDepositRequest(loginUser.getId(),
+            loginUserSavingAccountCreateResponse.getSavingAccountId(),
             10_000L);
 
-    int nThreads = 10;
+    // 친구 적금 계좌 입금 request
+    SavingAccountDepositRequest friendDepositRequest =
+        new SavingAccountDepositRequest(friend.getId(),
+            friendSavingAccountCreateResponse.getSavingAccountId(),
+            10_000L);
+
+    // 로그인 유저 송금 request
+    CheckingAccountWireRequest loginUserWireRequest = new CheckingAccountWireRequest(
+        loginUser.getId(), friend.getId(), 10_000L);
+
+    // 친구 송금 request
+    CheckingAccountWireRequest friendUserWireRequest = new CheckingAccountWireRequest(
+        friend.getId(), loginUser.getId(), 10_000L);
+
+    int nThreads = 100;
     int repeat = 5;
     ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
     CountDownLatch countDownLatch = new CountDownLatch(repeat);
@@ -81,8 +109,12 @@ public class AccountConcurrentTest {
     // when
     for (int i = 0; i < repeat; i++) {
       executorService.execute(() -> {
-        checkingAccountService.charge(chargeRequest);
-        savingAccountService.deposit(depositRequest);
+        checkingAccountService.charge(loginUserChargeRequest);
+        checkingAccountService.charge(friendChargeRequest);
+        savingAccountService.deposit(loginUserDepositRequest);
+        savingAccountService.deposit(friendDepositRequest);
+        checkingAccountService.wire(loginUserWireRequest);
+        checkingAccountService.wire(friendUserWireRequest);
         countDownLatch.countDown();
       });
     }
@@ -91,11 +123,23 @@ public class AccountConcurrentTest {
     executorService.shutdown();
 
     // then
-    CheckingAccount checkingAccount = checkingAccountRepository.findById(
-        savedCheckingAccount.getId()).get();
-    SavingAccount savingAccount = savingAccountRepository.findById(
-        savingAccountCreateResponse.getSavingAccountId()).get();
-    assertThat(checkingAccount.getBalance()).isEqualTo(100_000L);
-    assertThat(savingAccount.getAmount()).isEqualTo(50_000L);
+    CheckingAccount loginUserCheckingAccount = checkingAccountRepository.findByOwnerId(
+        loginUser.getId()).get();
+
+    CheckingAccount friendCheckingAccount = checkingAccountRepository.findByOwnerId(friend.getId())
+        .get();
+
+    SavingAccount loginUserSavingAccount = savingAccountRepository.findById(
+        loginUserSavingAccountCreateResponse.getSavingAccountId()).get();
+
+    SavingAccount friendSavingAccount = savingAccountRepository.findById(
+        friendSavingAccountCreateResponse.getSavingAccountId()).get();
+
+    // 메인계좌 100만원 (-)5 * 적금계좌입금, (+)5 * 메인계좌충전, (-)친구계좌에 송금, (+)친구계좌로부터 수신
+    assertThat(loginUserCheckingAccount.getBalance()).isEqualTo(1_000_000L);
+    assertThat(loginUserSavingAccount.getAmount()).isEqualTo(50_000L);
+
+    assertThat(friendCheckingAccount.getBalance()).isEqualTo(1_000_000L);
+    assertThat(friendSavingAccount.getAmount()).isEqualTo(50_000L);
   }
 }

--- a/src/test/java/com/jindo/minipay/account/savings/service/SavingAccountServiceTest.java
+++ b/src/test/java/com/jindo/minipay/account/savings/service/SavingAccountServiceTest.java
@@ -126,28 +126,9 @@ class SavingAccountServiceTest {
         .build();
 
     @Test
-    @DisplayName("실패 - 존재히지 않는 적금 계좌인 경우")
-    void deposit_not_found_saving_account() {
-
-      // given
-      given(savingAccountRepository.findByIdForUpdate(request.getSavingAccountId())).willThrow(
-          new CustomException(ACCOUNT_NOT_FOUND));
-
-      // when
-      // then
-      assertThatThrownBy(() -> savingAccountService.deposit(request))
-          .isInstanceOf(CustomException.class)
-          .hasMessage(ACCOUNT_NOT_FOUND.getMessage());
-    }
-
-    @Test
     @DisplayName("실패 - 존재히지 않는 회원인 경우")
     void deposit_not_found_member() {
-
       // given
-      given(savingAccountRepository.findByIdForUpdate(request.getSavingAccountId())).willReturn(
-          Optional.of(savingAccount));
-
       given(memberRepository.existsById(request.getOwnerId())).willReturn(false);
 
       // when
@@ -160,14 +141,29 @@ class SavingAccountServiceTest {
     @Test
     @DisplayName("실패 - 존재히지 않는 메인 계좌인 경우")
     void deposit_not_found_checking_account() {
-
       // given
-      given(savingAccountRepository.findByIdForUpdate(request.getSavingAccountId())).willReturn(
-          Optional.of(savingAccount));
-
       given(memberRepository.existsById(request.getOwnerId())).willReturn(true);
 
       given(checkingAccountRepository.findByOwnerIdForUpdate(request.getOwnerId())).willThrow(
+          new CustomException(ACCOUNT_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> savingAccountService.deposit(request))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(ACCOUNT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패 - 존재히지 않는 적금 계좌인 경우")
+    void deposit_not_found_saving_account() {
+      // given
+      given(memberRepository.existsById(request.getOwnerId())).willReturn(true);
+
+      given(checkingAccountRepository.findByOwnerIdForUpdate(request.getOwnerId())).willReturn(
+          Optional.of(checkingAccount));
+
+      given(savingAccountRepository.findByIdForUpdate(request.getSavingAccountId())).willThrow(
           new CustomException(ACCOUNT_NOT_FOUND));
 
       // when


### PR DESCRIPTION
## 친구에게 송금 API
### request 필드 기획
- 메인계좌간 송금 API를 추가했습니다. 카카오페이를 참고해보니, 송금 카테고리가 [친구 송금], [계좌 송금]으로 나뉘어져 있어서, 이번 요구사항 같은 경우 request의 필드를 각 회원의 id와 송금 금액인 amount로 기획하였습니다.

### Self-invocation 이슈
- 중간 로직에 '자동 충전'이 들어가있다보니, 기존에 작성해두었던 메인 계좌 충전 메소드를 재사용하고자 했습니다.
  - 같은 서비스 내에 존재하다보니 Self-invocation 이슈가 발생했고, `@Transactional`이 붙어있는 `charge()` 메소드를 바로 사용하지 않고, `charge()` 메소드내에서도 실제 충전기능을 하는 로직을 `actualCharge()`라는 메소드로 분리해내서, 송금 API에서도 `actualCharge()`메소드를 재사용하도록함으로써 해결했습니다.

### 데드락 이슈
- id가 1인 회원이 id가 2인 회원에게 송금하는 트랜잭션과, id가 2인 회원이 id가 1인 회원에게 송금하는 트랜잭션이 서로의 자원을 필요로 하는 상황이 발생했습니다.
```java
CheckingAccount senderAccount = getCheckingAccount(request.getSenderId());
CheckingAccount receiverAccount = getCheckingAccount(request.getReceiverId());
```
- 위 코드에서 `senderAccount`와 `receiverAccount`가 공용자원으로써 각각 1번자원, 2번자원이라고 했을 때, 각각의 트랜젝션이 senderAccount 레코드를 선점하게 되면, receiverAccount를 선점하려고 할 때, 이미 서로가 필요한 자원을 각각이 들고 있기 때문에 데드락이 발생했습니다.
- 이를 해결하기 위해, 자원을 선점할 때 순서대로 가져갈 수 있도록 작성했습니다.(memberId가 작은 순서대로 조회해오도록 하였습니다.)
- 코드가 조금 지저분하다고 생각해서 채택하고 싶지 않았지만, 별 다른 생각이 나질 않아서 사용하였습니다.
- `List<CheckingAccount>` 로 두 계좌를 모두 조회해오는 쿼리에 `@Lock`을 걸수도 있었지만, 가져오고 나서 List에서 request의 id값과 비교해줘야하는 번거로움이 존재했고, 리턴값이 List이다보니, 예외상황을 컨트롤 해줘야하기 때문에 채택하지 않았습니다.
- 데드락 부분은 추후에 더 리팩토링 할 예정입니다.