### PR TITLE
Feat/step3: 정산 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,9 @@ for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
 
 def jacocoExcludePatterns = [
 		"**/*Application*",
-		"**/*Config*",
-		"**/*Exception*",
-		"**/*Request*",
-		"**/*Response*",
-		"**/*Dto*",
+		"**/config/**",
+		"**/exception/**",
+		"**/dto/**",
 		"**/*Interceptor*",
 		"**/*Filter*",
 		"**/*Resolver*",

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ sonar {
 		property 'sonar.sources', 'src'
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+		// property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
 		property 'sonar.exclusions', jacocoExcludePatterns.join(',')
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ def jacocoExcludePatterns = [
 		"**/config/**",
 		"**/exception/**",
 		"**/dto/**",
+		"**/*Response*",
+		"**/*Request*",
 		"**/constant/**",
 		"**/*Interceptor*",
 		"**/*Filter*",

--- a/build.gradle
+++ b/build.gradle
@@ -2,68 +2,62 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.5'
-	// id 'jacoco'
-	 id "org.sonarqube" version "4.4.1.3373"
+	id 'jacoco'
+	id "org.sonarqube" version "4.4.1.3373"
 }
 
-//jacocoTestReport {
-//	dependsOn test
-//
-//	reports {
-//		html.required = true
-//		xml.required = true
-//
-//	}
+def Qdomains = []
+for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
+	Qdomains.add(qPattern + '*')
+}
 
-//	def Qdomains = []
-//	for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
-//		Qdomains.add(qPattern + '*')
-//	}
-//	afterEvaluate {
-//		classDirectories.setFrom(
-//				files(classDirectories.files.collect {
-//					fileTree(dir: it, excludes: [
-//							// 측정 안하고 싶은 패턴
-//							"**/global/*",
-//							"**/redis/*",
-//							"**/*Application*",
-//							"**/*Config*",
-//							"**/*Dto*",
-//							"**/*Request*",
-//							"**/*Response*",
-//							"**/*Interceptor*",
-//							"**/*Exception*"
-//							// Querydsl 관련 제거
-//					] + Qdomains)
-//				})
-//		)
-//	}
-//}
-//
-//// sonarCloud
-//sonar {
-//	properties {
-//		property "sonar.projectKey", "dojindo_minipay-jinyoung"
-//		property "sonar.organization", "dojindo"
-//		property 'sonar.host.url', 'https://sonarcloud.io'
-//		property 'sonar.sources', 'src'
-//		property 'sonar.language', 'java'
-//		property 'sonar.sourceEncoding', 'UTF-8'
-//		property 'sonar.test.inclusions', '**/*Test.java'
-//		property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java,' +
-//				'**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java'
-//		property 'sonar.java.coveragePlugin', 'jacoco'
-//		property 'sonar.java.binaries', "${buildDir}/classes"
-//		property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco.xml"
-//	}
-//}
+def jacocoExcludePatterns = [
+		"**/*Application*",
+		"**/*Config*",
+		"**/*Exception*",
+		"**/*Request*",
+		"**/*Response*",
+		"**/*Dto*",
+		"**/*Interceptor*",
+		"**/*Filter*",
+		"**/*Resolver*",
+		"**/*Entity*",
+		"**/test/**",
+		"**/resources/**",
+		"**/*BaseTimeEntity"
+] + Qdomains
 
+// jacoco
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		html.required = true
+		xml.required = true
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes: jacocoExcludePatterns)
+				})
+		)
+	}
+}
+
+// sonarqube
 sonar {
 	properties {
 		property "sonar.projectKey", "dojindo_minipay-jinyoung"
 		property "sonar.organization", "dojindo"
 		property 'sonar.host.url', 'https://sonarcloud.io'
-		property "sonar.sources", "src"
+		property 'sonar.sources', 'src'
+		property 'sonar.language', 'java'
+		property 'sonar.sourceEncoding', 'UTF-8'
+		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+		property 'sonar.test.inclusions', '**/*Test.java'
+		property 'sonar.java.coveragePlugin', 'jacoco'
+		property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
 	}
 }
 
@@ -101,5 +95,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
-	 // finalizedBy jacocoTestReport
+	finalizedBy jacocoTestReport
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.5'
 	// id 'jacoco'
-	// id "org.sonarqube" version "4.4.1.3373"
+	 id "org.sonarqube" version "4.4.1.3373"
 }
 
 //jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.5'
 	// id 'jacoco'
-	id "org.sonarqube" version "4.4.1.3373"
+	// id "org.sonarqube" version "4.4.1.3373"
 }
 
 //jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ sonar {
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
 		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+		property 'sonar.exclusions', jacocoExcludePatterns.join(',')
 		property 'sonar.test.inclusions', '**/*Test.java'
 		property 'sonar.java.coveragePlugin', 'jacoco'
 		property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ def jacocoExcludePatterns = [
 		"**/config/**",
 		"**/exception/**",
 		"**/dto/**",
+		"**/constant/**",
 		"**/*Interceptor*",
 		"**/*Filter*",
 		"**/*Resolver*",

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ def jacocoExcludePatterns = [
 		"**/config/**",
 		"**/exception/**",
 		"**/dto/**",
+		"**/annotation/**",
 		"**/constant/**",
 		"**/*Interceptor*",
 		"**/*Filter*",

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ sonar {
 		property "sonar.projectKey", "dojindo_minipay-jinyoung"
 		property "sonar.organization", "dojindo"
 		property 'sonar.host.url', 'https://sonarcloud.io'
+		property "sonar.sources", "src"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,14 @@ plugins {
 //	}
 //}
 
+sonar {
+	properties {
+		property "sonar.projectKey", "dojindo_minipay-jinyoung"
+		property "sonar.organization", "dojindo"
+		property 'sonar.host.url', 'https://sonarcloud.io'
+	}
+}
+
 group = 'com.jindo'
 version = '0.0.1-SNAPSHOT'
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,61 +2,61 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'
 	id 'io.spring.dependency-management' version '1.1.5'
-	id 'jacoco'
+	// id 'jacoco'
 	id "org.sonarqube" version "4.4.1.3373"
 }
 
-jacocoTestReport {
-	dependsOn test
+//jacocoTestReport {
+//	dependsOn test
+//
+//	reports {
+//		html.required = true
+//		xml.required = true
+//
+//	}
 
-	reports {
-		html.required = true
-		xml.required = true
-
-	}
-
-	def Qdomains = []
-	for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
-		Qdomains.add(qPattern + '*')
-	}
-	afterEvaluate {
-		classDirectories.setFrom(
-				files(classDirectories.files.collect {
-					fileTree(dir: it, excludes: [
-							// 측정 안하고 싶은 패턴
-							"**/global/*",
-							"**/redis/*",
-							"**/*Application*",
-							"**/*Config*",
-							"**/*Dto*",
-							"**/*Request*",
-							"**/*Response*",
-							"**/*Interceptor*",
-							"**/*Exception*"
-							// Querydsl 관련 제거
-					] + Qdomains)
-				})
-		)
-	}
-}
-
-// sonarCloud
-sonarqube {
-	properties {
-		property "sonar.projectKey", "dojindo_minipay-jinyoung"
-		property "sonar.organization", "dojindo"
-		property 'sonar.host.url', 'https://sonarcloud.io'
-		property 'sonar.sources', 'src'
-		property 'sonar.language', 'java'
-		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.test.inclusions', '**/*Test.java'
-		property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java,' +
-				'**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java'
-		property 'sonar.java.coveragePlugin', 'jacoco'
-		property 'sonar.java.binaries', "${buildDir}/classes"
-		property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco.xml"
-	}
-}
+//	def Qdomains = []
+//	for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
+//		Qdomains.add(qPattern + '*')
+//	}
+//	afterEvaluate {
+//		classDirectories.setFrom(
+//				files(classDirectories.files.collect {
+//					fileTree(dir: it, excludes: [
+//							// 측정 안하고 싶은 패턴
+//							"**/global/*",
+//							"**/redis/*",
+//							"**/*Application*",
+//							"**/*Config*",
+//							"**/*Dto*",
+//							"**/*Request*",
+//							"**/*Response*",
+//							"**/*Interceptor*",
+//							"**/*Exception*"
+//							// Querydsl 관련 제거
+//					] + Qdomains)
+//				})
+//		)
+//	}
+//}
+//
+//// sonarCloud
+//sonar {
+//	properties {
+//		property "sonar.projectKey", "dojindo_minipay-jinyoung"
+//		property "sonar.organization", "dojindo"
+//		property 'sonar.host.url', 'https://sonarcloud.io'
+//		property 'sonar.sources', 'src'
+//		property 'sonar.language', 'java'
+//		property 'sonar.sourceEncoding', 'UTF-8'
+//		property 'sonar.test.inclusions', '**/*Test.java'
+//		property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/** ,**/*Application*.java , **/*Config*.java,' +
+//				'**/*Dto*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java'
+//		property 'sonar.java.coveragePlugin', 'jacoco'
+//		property 'sonar.java.binaries', "${buildDir}/classes"
+//		property 'sonar.coverage.jacoco.xmlReportPaths', "${buildDir}/reports/jacoco.xml"
+//	}
+//}
 
 group = 'com.jindo'
 version = '0.0.1-SNAPSHOT'
@@ -92,5 +92,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
-	finalizedBy jacocoTestReport
+	 // finalizedBy jacocoTestReport
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,62 +6,6 @@ plugins {
 	id "org.sonarqube" version "4.4.1.3373"
 }
 
-def Qdomains = []
-for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
-	Qdomains.add(qPattern + '*')
-}
-
-def jacocoExcludePatterns = [
-		"**/*Application*",
-		"**/config/**",
-		"**/exception/**",
-		"**/dto/**",
-		"**/*Response*",
-		"**/*Request*",
-		"**/constant/**",
-		"**/*Interceptor*",
-		"**/*Filter*",
-		"**/*Resolver*",
-		"**/*Entity*",
-		"**/test/**",
-		"**/resources/**",
-		"**/*BaseTimeEntity"
-] + Qdomains
-
-// jacoco
-jacocoTestReport {
-	dependsOn test
-
-	reports {
-		html.required = true
-		xml.required = true
-	}
-
-	afterEvaluate {
-		classDirectories.setFrom(
-				files(classDirectories.files.collect {
-					fileTree(dir: it, excludes: jacocoExcludePatterns)
-				})
-		)
-	}
-}
-
-// sonarqube
-sonar {
-	properties {
-		property "sonar.projectKey", "dojindo_minipay-jinyoung"
-		property "sonar.organization", "dojindo"
-		property 'sonar.host.url', 'https://sonarcloud.io'
-		property 'sonar.sources', 'src'
-		property 'sonar.language', 'java'
-		property 'sonar.sourceEncoding', 'UTF-8'
-		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
-		property 'sonar.test.inclusions', '**/*Test.java'
-		property 'sonar.java.coveragePlugin', 'jacoco'
-		property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
-	}
-}
-
 group = 'com.jindo'
 version = '0.0.1-SNAPSHOT'
 
@@ -97,4 +41,57 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
+}
+
+def Qdomains = []
+for (qPattern in '**/QA'..'**/QZ') { // qPattern = '**/QA', '**/QB', ... '*.QZ'
+	Qdomains.add(qPattern + '*')
+}
+
+def jacocoExcludePatterns = [
+		"**/*Application*",
+		"**/config/**",
+		"**/exception/**",
+		"**/dto/**",
+		"**/constant/**",
+		"**/*Interceptor*",
+		"**/*Filter*",
+		"**/*Resolver*",
+		"**/*Entity*",
+		"**/test/**",
+		"**/resources/**"
+] + Qdomains
+
+// jacoco
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		html.required = true
+		xml.required = true
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(
+				files(classDirectories.files.collect {
+					fileTree(dir: it, excludes: jacocoExcludePatterns)
+				})
+		)
+	}
+}
+
+// sonarqube
+sonar {
+	properties {
+		property "sonar.projectKey", "dojindo_minipay-jinyoung"
+		property "sonar.organization", "dojindo"
+		property 'sonar.host.url', 'https://sonarcloud.io'
+		property 'sonar.sources', 'src'
+		property 'sonar.language', 'java'
+		property 'sonar.sourceEncoding', 'UTF-8'
+		property 'sonar.test.exclusions', jacocoExcludePatterns.join(',')
+		property 'sonar.test.inclusions', '**/*Test.java'
+		property 'sonar.java.coveragePlugin', 'jacoco'
+		property 'sonar.coverage.jacoco.xmlReportPaths', "build/reports/jacoco/test/jacocoTestReport.xml"
+	}
 }

--- a/src/main/http/settle.http
+++ b/src/main/http/settle.http
@@ -1,0 +1,11 @@
+### 정산 요청
+POST http://localhost:8080/settle/distribute
+Content-Type: application/json
+
+{
+  "requesterId": 1,
+  "participantsSize": 3,
+  "amount": 2,
+  "settlementType": "EQUAL"
+}
+

--- a/src/main/http/settle.http
+++ b/src/main/http/settle.http
@@ -1,11 +1,22 @@
-### 정산 요청
+### 정산 금액 분배 요청
 POST http://localhost:8080/settle/distribute
 Content-Type: application/json
 
 {
   "requesterId": 1,
   "participantsSize": 3,
-  "amount": 2,
+  "totalAmount": 3,
   "settlementType": "EQUAL"
+}
+
+### 정산 금액 분배 요청(실패 : 유효하지 않은 정산타입)
+POST http://localhost:8080/settle/distribute
+Content-Type: application/json
+
+{
+  "requesterId": 1,
+  "participantsSize": 3,
+  "totalAmount": 3,
+  "settlementType": "NONE"
 }
 

--- a/src/main/java/com/jindo/minipay/account/common/util/AccountNumberCreator.java
+++ b/src/main/java/com/jindo/minipay/account/common/util/AccountNumberCreator.java
@@ -6,6 +6,7 @@ import static com.jindo.minipay.account.common.type.AccountType.SAVING;
 import com.jindo.minipay.account.checking.repository.CheckingAccountRepository;
 import com.jindo.minipay.account.common.type.AccountType;
 import com.jindo.minipay.account.savings.repository.SavingAccountRepository;
+import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,11 +19,12 @@ public class AccountNumberCreator {
 
   public String create(AccountType accountType) {
     StringBuilder sb = new StringBuilder();
+    SecureRandom secureRandom = new SecureRandom();
 
     sb.append(accountType.getCode());
 
     for (int i = 0; i < 8; i++) {
-      sb.append((int) (Math.random() * 10));
+      sb.append(secureRandom.nextInt(10));
     }
 
     boolean exists = false;

--- a/src/main/java/com/jindo/minipay/global/annotation/ValidEnum.java
+++ b/src/main/java/com/jindo/minipay/global/annotation/ValidEnum.java
@@ -1,0 +1,24 @@
+package com.jindo.minipay.global.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.jindo.minipay.global.annotation.validator.EnumValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({METHOD, FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {EnumValidator.class})
+public @interface ValidEnum {
+  String message() default "유효하지 않은 값입니다.";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+  Class<? extends Enum<?>> enumClass();
+}

--- a/src/main/java/com/jindo/minipay/global/annotation/validator/EnumValidator.java
+++ b/src/main/java/com/jindo/minipay/global/annotation/validator/EnumValidator.java
@@ -1,0 +1,33 @@
+package com.jindo.minipay.global.annotation.validator;
+
+import com.jindo.minipay.global.annotation.ValidEnum;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum<?>> {
+
+  private ValidEnum annotation;
+
+  @Override
+  public void initialize(ValidEnum constraintAnnotation) {
+    annotation = constraintAnnotation;
+  }
+
+  @Override
+  public boolean isValid(Enum value, ConstraintValidatorContext context) {
+    boolean result = false;
+    Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+
+    if (enumValues == null) {
+      return false;
+    }
+
+    for (Object enumValue : enumValues) {
+      if (value == enumValue) {
+        result = true;
+        break;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/jindo/minipay/global/exception/ErrorCode.java
+++ b/src/main/java/com/jindo/minipay/global/exception/ErrorCode.java
@@ -11,10 +11,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
   ALREADY_EXISTS_USERNAME(SC_CONFLICT, "중복된 ID 입니다."),
+
   ACCOUNT_NOT_FOUND(SC_NOT_FOUND, "존재하지 않는 계좌입니다."),
   MEMBER_NOT_FOUND(SC_NOT_FOUND, "존재하지 않는 회원입니다."),
+
+  INVALID_PARTICIPANT(SC_NOT_FOUND, "유효하지 않은 참여자입니다."),
+
   CHARGE_LIMIT_EXCEEDED(SC_BAD_REQUEST, "금일 충전 한도를 초과하였습니다."),
-  BALANCE_NOT_ENOUGH(SC_BAD_REQUEST, "메인 계좌에 잔액이 부족합니다.");
+  NOT_EXISTS_SETTLE_TYPE(SC_BAD_REQUEST, "존재하지 않는 정산 방법입니다."),
+  BALANCE_NOT_ENOUGH(SC_BAD_REQUEST, "메인 계좌에 잔액이 부족합니다."),
+  INSUFFICIENT_SETTLE_AMOUNT(SC_BAD_REQUEST, "정산 금액이 너무 적습니다."),
+  INVALID_SETTLE_REQUEST(SC_BAD_REQUEST, "유효하지 않은 요청입니다.");
+
 
   private final int code;
 

--- a/src/main/java/com/jindo/minipay/member/repository/MemberRepository.java
+++ b/src/main/java/com/jindo/minipay/member/repository/MemberRepository.java
@@ -1,12 +1,15 @@
 package com.jindo.minipay.member.repository;
 
 import com.jindo.minipay.member.entity.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByUsername(String username);
+
+  List<Member> findByIdIn(List<Long> ids);
 
   boolean existsByUsername(String username);
 }

--- a/src/main/java/com/jindo/minipay/settlement/constant/SettlementConstants.java
+++ b/src/main/java/com/jindo/minipay/settlement/constant/SettlementConstants.java
@@ -1,0 +1,13 @@
+package com.jindo.minipay.settlement.constant;
+
+public class SettlementConstants {
+
+  public static final int SETTLEMENT_PARTICIPANTS_MIN_SIZE = 2;
+  public static final int SETTLEMENT_PARTICIPANTS_MAX_SIZE = 50;
+
+  public static final long SETTLEMENT_DISTRIBUTE_MIN_AMOUNT = 1L;
+  public static final long SETTLEMENT_DISTRIBUTE_MAX_AMOUNT = 5_000_000L;
+
+  public static final long RANDOM_SETTLEMENT_MIN_AMOUNT = 1_000L;
+  public static final long RANDOM_SETTLEMENT_UNIT = 100L;
+}

--- a/src/main/java/com/jindo/minipay/settlement/controller/SettlementController.java
+++ b/src/main/java/com/jindo/minipay/settlement/controller/SettlementController.java
@@ -1,0 +1,40 @@
+package com.jindo.minipay.settlement.controller;
+
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.service.SettlementServiceFinder;
+import com.jindo.minipay.settlement.dto.SettleRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/settle")
+public class SettlementController {
+
+  private final SettlementServiceFinder settlementServiceFinder;
+
+  /**
+   * 정산 분배금액 계산
+   */
+  @PostMapping("/distribute")
+  public ResponseEntity<SettleDistributeResponse> distribute(@RequestBody @Valid SettleDistributeRequest request) {
+    return ResponseEntity.ok(settlementServiceFinder.find(request.getSettlementType()).distribute(request));
+  }
+
+  /**
+   * 정산 요청
+   */
+  @PostMapping
+  public ResponseEntity<Void> settle(@RequestBody @Valid SettleRequest request) {
+    request.additionalValidate();
+    Long settleId = settlementServiceFinder.find(request.getSettlementType()).settle(request);
+    return ResponseEntity.created(URI.create("/settle/" + settleId)).build();
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeRequest.java
+++ b/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeRequest.java
@@ -1,0 +1,28 @@
+package com.jindo.minipay.settlement.dto;
+
+import static com.jindo.minipay.settlement.constant.SettlementConstants.*;
+
+import com.jindo.minipay.settlement.type.SettlementType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SettleDistributeRequest {
+
+  @NotNull
+  private Long requesterId;
+
+  @Min(SETTLEMENT_PARTICIPANTS_MIN_SIZE) @Max(SETTLEMENT_PARTICIPANTS_MAX_SIZE)
+  private int participantsSize;
+
+  @Min(SETTLEMENT_DISTRIBUTE_MIN_AMOUNT) @Max(SETTLEMENT_DISTRIBUTE_MAX_AMOUNT)
+  private long totalAmount;
+
+  @NotNull
+  private SettlementType settlementType;
+
+}

--- a/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeRequest.java
+++ b/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeRequest.java
@@ -2,6 +2,8 @@ package com.jindo.minipay.settlement.dto;
 
 import static com.jindo.minipay.settlement.constant.SettlementConstants.*;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.jindo.minipay.global.annotation.ValidEnum;
 import com.jindo.minipay.settlement.type.SettlementType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -22,7 +24,6 @@ public class SettleDistributeRequest {
   @Min(SETTLEMENT_DISTRIBUTE_MIN_AMOUNT) @Max(SETTLEMENT_DISTRIBUTE_MAX_AMOUNT)
   private long totalAmount;
 
-  @NotNull
+  @ValidEnum(enumClass = SettlementType.class)
   private SettlementType settlementType;
-
 }

--- a/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeResponse.java
+++ b/src/main/java/com/jindo/minipay/settlement/dto/SettleDistributeResponse.java
@@ -1,0 +1,31 @@
+package com.jindo.minipay.settlement.dto;
+
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public class SettleDistributeResponse {
+
+  private final long[] splitAmounts;
+
+  private long supportsAmount;
+
+  public static SettleDistributeResponse ofEqualSettle(int participantsSize, long splitAmount,
+      long supportsAmount) {
+    return new SettleDistributeResponse(participantsSize, splitAmount, supportsAmount);
+  }
+
+  public static SettleDistributeResponse ofRandomSettle(long[] splitAmounts) {
+    return new SettleDistributeResponse(splitAmounts);
+  }
+
+  private SettleDistributeResponse(int participantsSize, long splitAmount, long supportsAmount) {
+    this.splitAmounts = new long[participantsSize];
+    Arrays.fill(splitAmounts, splitAmount);
+    this.supportsAmount = supportsAmount;
+  }
+
+  private SettleDistributeResponse(long[] splitAmounts) {
+    this.splitAmounts = splitAmounts;
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/dto/SettleRequest.java
+++ b/src/main/java/com/jindo/minipay/settlement/dto/SettleRequest.java
@@ -7,6 +7,7 @@ import static com.jindo.minipay.settlement.constant.SettlementConstants.RANDOM_S
 import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MAX_SIZE;
 import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MIN_SIZE;
 
+import com.jindo.minipay.global.annotation.ValidEnum;
 import com.jindo.minipay.global.exception.CustomException;
 import com.jindo.minipay.member.entity.Member;
 import com.jindo.minipay.settlement.entity.Settlement;
@@ -43,7 +44,7 @@ public class SettleRequest {
   @Size(min = SETTLEMENT_PARTICIPANTS_MIN_SIZE, max = SETTLEMENT_PARTICIPANTS_MAX_SIZE)
   private long[] amounts;
 
-  @NotNull
+  @ValidEnum(enumClass = SettlementType.class)
   private SettlementType settlementType;
 
   public Settlement toEntity(Member requester) {

--- a/src/main/java/com/jindo/minipay/settlement/dto/SettleRequest.java
+++ b/src/main/java/com/jindo/minipay/settlement/dto/SettleRequest.java
@@ -1,0 +1,71 @@
+package com.jindo.minipay.settlement.dto;
+
+import static com.jindo.minipay.settlement.type.SettlementType.RANDOM;
+import static com.jindo.minipay.global.exception.ErrorCode.INSUFFICIENT_SETTLE_AMOUNT;
+import static com.jindo.minipay.global.exception.ErrorCode.INVALID_SETTLE_REQUEST;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.RANDOM_SETTLEMENT_MIN_AMOUNT;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MAX_SIZE;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MIN_SIZE;
+
+import com.jindo.minipay.global.exception.CustomException;
+import com.jindo.minipay.member.entity.Member;
+import com.jindo.minipay.settlement.entity.Settlement;
+import com.jindo.minipay.settlement.type.SettlementType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettleRequest {
+
+  @NotNull
+  private Long requesterId;
+
+  @NotEmpty
+  @Size(min = SETTLEMENT_PARTICIPANTS_MIN_SIZE, max = SETTLEMENT_PARTICIPANTS_MAX_SIZE)
+  private List<Long> participantIds;
+
+  @Min(SETTLEMENT_PARTICIPANTS_MIN_SIZE)
+  private long totalAmount;
+
+  @PositiveOrZero
+  private long supportsAmount;
+
+  @NotEmpty
+  @Size(min = SETTLEMENT_PARTICIPANTS_MIN_SIZE, max = SETTLEMENT_PARTICIPANTS_MAX_SIZE)
+  private long[] amounts;
+
+  @NotNull
+  private SettlementType settlementType;
+
+  public Settlement toEntity(Member requester) {
+    return Settlement.builder()
+        .requester(requester)
+        .totalAmount(totalAmount)
+        .supportsAmount(supportsAmount)
+        .settlementType(settlementType)
+        .build();
+  }
+
+  public void additionalValidate() {
+    if (getParticipantIds().size() != amounts.length) {
+      throw new CustomException(INVALID_SETTLE_REQUEST);
+    }
+
+    if (getParticipantIds().size() > getTotalAmount()) {
+      throw new CustomException(INSUFFICIENT_SETTLE_AMOUNT);
+    }
+
+    if (getSettlementType() == RANDOM && getTotalAmount() < RANDOM_SETTLEMENT_MIN_AMOUNT) {
+      throw new CustomException(INSUFFICIENT_SETTLE_AMOUNT);
+    }
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/entity/ParticipantSettlement.java
+++ b/src/main/java/com/jindo/minipay/settlement/entity/ParticipantSettlement.java
@@ -1,0 +1,45 @@
+package com.jindo.minipay.settlement.entity;
+
+import com.jindo.minipay.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParticipantSettlement {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(nullable = false)
+  private Settlement settlement;
+
+  @ManyToOne
+  @JoinColumn(nullable = false)
+  private Member participant;
+
+  @Column(nullable = false)
+  private long amount;
+
+  public static ParticipantSettlement of(Settlement savedSettlement, Member participant, long amount) {
+    return ParticipantSettlement.builder()
+        .settlement(savedSettlement)
+        .participant(participant)
+        .amount(amount)
+        .build();
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/entity/ParticipantSettlement.java
+++ b/src/main/java/com/jindo/minipay/settlement/entity/ParticipantSettlement.java
@@ -1,5 +1,6 @@
 package com.jindo.minipay.settlement.entity;
 
+import com.jindo.minipay.global.entity.BaseTimeEntity;
 import com.jindo.minipay.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ParticipantSettlement {
+public class ParticipantSettlement extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jindo/minipay/settlement/entity/Settlement.java
+++ b/src/main/java/com/jindo/minipay/settlement/entity/Settlement.java
@@ -1,0 +1,40 @@
+package com.jindo.minipay.settlement.entity;
+
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.global.entity.BaseTimeEntity;
+import com.jindo.minipay.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Settlement extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(nullable = false)
+  private Member requester;
+
+  private long totalAmount;
+
+  private long supportsAmount;
+
+  @Column(nullable = false)
+  private SettlementType settlementType;
+
+}

--- a/src/main/java/com/jindo/minipay/settlement/entity/Settlement.java
+++ b/src/main/java/com/jindo/minipay/settlement/entity/Settlement.java
@@ -5,6 +5,8 @@ import com.jindo.minipay.global.entity.BaseTimeEntity;
 import com.jindo.minipay.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,6 +37,7 @@ public class Settlement extends BaseTimeEntity {
   private long supportsAmount;
 
   @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   private SettlementType settlementType;
 
 }

--- a/src/main/java/com/jindo/minipay/settlement/repository/ParticipantSettlementRepository.java
+++ b/src/main/java/com/jindo/minipay/settlement/repository/ParticipantSettlementRepository.java
@@ -1,0 +1,8 @@
+package com.jindo.minipay.settlement.repository;
+
+import com.jindo.minipay.settlement.entity.ParticipantSettlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantSettlementRepository extends JpaRepository<ParticipantSettlement, Long> {
+
+}

--- a/src/main/java/com/jindo/minipay/settlement/repository/SettlementRepository.java
+++ b/src/main/java/com/jindo/minipay/settlement/repository/SettlementRepository.java
@@ -1,0 +1,8 @@
+package com.jindo.minipay.settlement.repository;
+
+import com.jindo.minipay.settlement.entity.Settlement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+}

--- a/src/main/java/com/jindo/minipay/settlement/service/EqualSettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/EqualSettlementService.java
@@ -1,0 +1,33 @@
+package com.jindo.minipay.settlement.service;
+
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlement.repository.ParticipantSettlementRepository;
+import com.jindo.minipay.settlement.repository.SettlementRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EqualSettlementService extends SettlementService {
+
+  public EqualSettlementService(MemberRepository memberRepository,
+      SettlementRepository settlementRepository,
+      ParticipantSettlementRepository participantSettlementRepository) {
+    super(memberRepository, settlementRepository, participantSettlementRepository);
+  }
+
+  @Override
+  public SettlementType getType() {
+    return SettlementType.EQUAL;
+  }
+
+  @Override
+  public SettleDistributeResponse distribute(SettleDistributeRequest request) {
+    long splitAmount = request.getTotalAmount() / request.getParticipantsSize();
+    long supportsAmount = request.getTotalAmount() % request.getParticipantsSize();
+
+    return SettleDistributeResponse.ofEqualSettle(
+        request.getParticipantsSize(), splitAmount, supportsAmount);
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
@@ -1,0 +1,73 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.settlement.constant.SettlementConstants.RANDOM_SETTLEMENT_UNIT;
+
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlement.repository.ParticipantSettlementRepository;
+import com.jindo.minipay.settlement.repository.SettlementRepository;
+import java.util.Random;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RandomSettlementService extends SettlementService {
+
+  public RandomSettlementService(
+      MemberRepository memberRepository,
+      SettlementRepository settlementRepository,
+      ParticipantSettlementRepository participantSettlementRepository) {
+    super(memberRepository, settlementRepository, participantSettlementRepository);
+  }
+
+  @Override
+  public SettlementType getType() {
+    return SettlementType.RANDOM;
+  }
+
+  @Override
+  public SettleDistributeResponse distribute(SettleDistributeRequest request) {
+    long[] settleAmounts = splitAmountAndShuffle(
+        request.getTotalAmount(), request.getParticipantsSize());
+
+    return SettleDistributeResponse.ofRandomSettle(settleAmounts);
+  }
+
+  private long[] splitAmountAndShuffle(long totalAmount, int participantsSize) {
+    long[] settleAmounts = new long[participantsSize];
+    Random random = new Random();
+
+    int index = 0;
+    while (totalAmount != 0 && index != participantsSize) {
+      if (index == participantsSize - 1) {
+        settleAmounts[index] = totalAmount;
+        break;
+      }
+
+      long share = totalAmount / RANDOM_SETTLEMENT_UNIT;
+      long amountPerParticipant = random.nextLong(share) * RANDOM_SETTLEMENT_UNIT;
+
+      if (amountPerParticipant == 0) {
+        amountPerParticipant = totalAmount % RANDOM_SETTLEMENT_UNIT;
+      }
+
+      settleAmounts[index++] = amountPerParticipant;
+      totalAmount -= amountPerParticipant;
+    }
+
+    shuffleArray(settleAmounts);
+    return settleAmounts;
+  }
+
+  private void shuffleArray(long[] arr) {
+    Random random = new Random();
+    for (int i = arr.length - 1; i > 0; i--) {
+      int index = random.nextInt(i + 1);
+
+      long temp = arr[index];
+      arr[index] = arr[i];
+      arr[i] = temp;
+    }
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
@@ -48,10 +48,6 @@ public class RandomSettlementService extends SettlementService {
       long share = totalAmount / RANDOM_SETTLEMENT_UNIT;
       long amountPerParticipant = random.nextLong(share) * RANDOM_SETTLEMENT_UNIT;
 
-      if (amountPerParticipant == 0) {
-        amountPerParticipant = totalAmount % RANDOM_SETTLEMENT_UNIT;
-      }
-
       settleAmounts[index++] = amountPerParticipant;
       totalAmount -= amountPerParticipant;
     }

--- a/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
@@ -46,6 +46,11 @@ public class RandomSettlementService extends SettlementService {
       }
 
       long share = totalAmount / RANDOM_SETTLEMENT_UNIT;
+
+      if (share == 0) {
+        settleAmounts[index] = totalAmount;
+        break;
+      }
       long amountPerParticipant = random.nextLong(share) * RANDOM_SETTLEMENT_UNIT;
 
       settleAmounts[index++] = amountPerParticipant;

--- a/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/RandomSettlementService.java
@@ -39,7 +39,7 @@ public class RandomSettlementService extends SettlementService {
     Random random = new Random();
 
     int index = 0;
-    while (totalAmount != 0 && index != participantsSize) {
+    while (totalAmount != 0) {
       if (index == participantsSize - 1) {
         settleAmounts[index] = totalAmount;
         break;

--- a/src/main/java/com/jindo/minipay/settlement/service/SettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/SettlementService.java
@@ -65,12 +65,7 @@ public abstract class SettlementService {
       long amount = amounts[i];
 
       participantSettlementRepository.save(
-          createParticipantSettlement(savedSettlement, participant, amount));
+          ParticipantSettlement.of(savedSettlement, participant, amount));
     });
-  }
-
-  private ParticipantSettlement createParticipantSettlement(
-      Settlement savedSettlement, Member participant, long amount) {
-    return ParticipantSettlement.of(savedSettlement, participant, amount);
   }
 }

--- a/src/main/java/com/jindo/minipay/settlement/service/SettlementService.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/SettlementService.java
@@ -1,0 +1,76 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.global.exception.ErrorCode.INVALID_PARTICIPANT;
+import static com.jindo.minipay.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.global.exception.CustomException;
+import com.jindo.minipay.member.entity.Member;
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlement.dto.SettleRequest;
+import com.jindo.minipay.settlement.entity.ParticipantSettlement;
+import com.jindo.minipay.settlement.entity.Settlement;
+import com.jindo.minipay.settlement.repository.ParticipantSettlementRepository;
+import com.jindo.minipay.settlement.repository.SettlementRepository;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public abstract class SettlementService {
+
+  private final MemberRepository memberRepository;
+  private final SettlementRepository settlementRepository;
+  private final ParticipantSettlementRepository participantSettlementRepository;
+
+  public abstract SettleDistributeResponse distribute(SettleDistributeRequest request);
+
+  public abstract SettlementType getType();
+
+  @Transactional
+  public Long settle(SettleRequest request) {
+    List<Member> participants = getParticipants(request.getParticipantIds());
+    long[] amounts = request.getAmounts();
+
+    Member requester = getMember(request.getRequesterId());
+
+    Settlement savedSettlement = settlementRepository.save(request.toEntity(requester));
+
+    saveParticipantSettlement(participants, amounts, savedSettlement);
+    return savedSettlement.getId();
+  }
+
+  private List<Member> getParticipants(List<Long> participantsId) {
+    List<Member> participants = memberRepository.findByIdIn(participantsId);
+
+    if (participants.size() != participantsId.size()) {
+      throw new CustomException(INVALID_PARTICIPANT);
+    }
+
+    return participants;
+  }
+
+  private Member getMember(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+  }
+
+  private void saveParticipantSettlement(List<Member> participants, long[] amounts,
+      Settlement savedSettlement) {
+    IntStream.range(0, amounts.length).forEach(i -> {
+      Member participant = participants.get(i);
+      long amount = amounts[i];
+
+      participantSettlementRepository.save(
+          createParticipantSettlement(savedSettlement, participant, amount));
+    });
+  }
+
+  private ParticipantSettlement createParticipantSettlement(
+      Settlement savedSettlement, Member participant, long amount) {
+    return ParticipantSettlement.of(savedSettlement, participant, amount);
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/service/SettlementServiceFinder.java
+++ b/src/main/java/com/jindo/minipay/settlement/service/SettlementServiceFinder.java
@@ -1,0 +1,21 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.global.exception.ErrorCode.NOT_EXISTS_SETTLE_TYPE;
+
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.global.exception.CustomException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementServiceFinder {
+
+  private final List<SettlementService> settlementServices;
+
+  public SettlementService find(SettlementType settlementType) {
+    return settlementServices.stream().filter(settlementService -> settlementService.getType() == settlementType)
+        .findAny().orElseThrow(() -> new CustomException(NOT_EXISTS_SETTLE_TYPE));
+  }
+}

--- a/src/main/java/com/jindo/minipay/settlement/type/SettlementType.java
+++ b/src/main/java/com/jindo/minipay/settlement/type/SettlementType.java
@@ -1,0 +1,9 @@
+package com.jindo.minipay.settlement.type;
+
+/**
+ * ORIGINAL: 1/N으로 금액을 나눠서 정산
+ * RANDOM: 랜덤으로 금액을 나눠서 정산
+ */
+public enum SettlementType {
+  EQUAL, RANDOM
+}

--- a/src/main/java/com/jindo/minipay/settlement/type/SettlementType.java
+++ b/src/main/java/com/jindo/minipay/settlement/type/SettlementType.java
@@ -1,9 +1,20 @@
 package com.jindo.minipay.settlement.type;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+
 /**
- * ORIGINAL: 1/N으로 금액을 나눠서 정산
+ * EQUAL: 1/N으로 금액을 나눠서 정산
  * RANDOM: 랜덤으로 금액을 나눠서 정산
  */
 public enum SettlementType {
-  EQUAL, RANDOM
+  EQUAL, RANDOM;
+
+  @JsonCreator
+  public static SettlementType initialize(String value) {
+    return Arrays.stream(SettlementType.values())
+        .filter(enumValue -> enumValue.name().equals(value))
+        .findFirst()
+        .orElse(null);
+  }
 }

--- a/src/test/java/com/jindo/minipay/settlement/controller/SettlementControllerTest.java
+++ b/src/test/java/com/jindo/minipay/settlement/controller/SettlementControllerTest.java
@@ -1,0 +1,453 @@
+package com.jindo.minipay.settlement.controller;
+
+import static com.jindo.minipay.settlement.type.SettlementType.EQUAL;
+import static com.jindo.minipay.settlement.type.SettlementType.RANDOM;
+import static com.jindo.minipay.global.exception.ErrorCode.INSUFFICIENT_SETTLE_AMOUNT;
+import static com.jindo.minipay.global.exception.ErrorCode.INVALID_SETTLE_REQUEST;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.RANDOM_SETTLEMENT_MIN_AMOUNT;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_DISTRIBUTE_MAX_AMOUNT;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_DISTRIBUTE_MIN_AMOUNT;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MAX_SIZE;
+import static com.jindo.minipay.settlement.constant.SettlementConstants.SETTLEMENT_PARTICIPANTS_MIN_SIZE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.dto.SettleRequest;
+import com.jindo.minipay.settlement.service.EqualSettlementService;
+import com.jindo.minipay.settlement.service.RandomSettlementService;
+import com.jindo.minipay.settlement.service.SettlementServiceFinder;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SettlementController.class)
+class SettlementControllerTest {
+
+  @MockBean
+  SettlementServiceFinder settlementServiceFinder;
+
+  @MockBean
+  EqualSettlementService equalSettlementService;
+
+  @MockBean
+  RandomSettlementService randomSettlementService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  static final String URI = "/settle";
+
+  @Nested
+  @DisplayName("정산 분배금액 계산")
+  class SettleDistributeMethod {
+
+    @Test
+    @DisplayName("실패 - 요청자 ID가 null인 경우")
+    void distribute_requesterId_null() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          null, SETTLEMENT_PARTICIPANTS_MIN_SIZE, 10_000L, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 최소 참여자 수보다 적은 요청인 경우")
+    void distribute_participants_size_smaller_than_min() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE - 1, 10_000L, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 최대 참여자 수보다 많은 요청인 경우")
+    void distribute_participants_size_bigger_than_max() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MAX_SIZE + 1, 10_000L, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 정산 금액이 최소 요구사항보다 적은 경우")
+    void distribute_total_amount_smaller_than_min() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE, SETTLEMENT_DISTRIBUTE_MIN_AMOUNT - 1,
+          EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 정산 금액이 최대 요구사항보다 많은 경우")
+    void distribute_total_amount_bigger_than_max() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE, SETTLEMENT_DISTRIBUTE_MAX_AMOUNT + 1,
+          EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 정산 타입이 null인 경우")
+    void distribute_settle_type_null() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE, SETTLEMENT_DISTRIBUTE_MIN_AMOUNT, null);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공 - 1/N 정산 금액 분배")
+    void distribute_of_equal_settle() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE, SETTLEMENT_DISTRIBUTE_MAX_AMOUNT,
+          EQUAL);
+
+      long splitAmount = request.getTotalAmount() / request.getParticipantsSize();
+      long supportsAmount = request.getTotalAmount() % request.getParticipantsSize();
+      SettleDistributeResponse response = SettleDistributeResponse.ofEqualSettle(
+          request.getParticipantsSize(), splitAmount, supportsAmount);
+
+      // when
+      when(settlementServiceFinder.find(request.getSettlementType())).thenReturn(
+          equalSettlementService);
+      when(equalSettlementService.distribute(any())).thenReturn(response);
+
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isOk())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공 - 랜덤 정산 금액 분배")
+    void distribute_of_random_settle() throws Exception {
+      // given
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          1L, SETTLEMENT_PARTICIPANTS_MIN_SIZE, SETTLEMENT_DISTRIBUTE_MAX_AMOUNT,
+          RANDOM);
+
+      long[] splitAmounts = new long[request.getParticipantsSize()];
+      SettleDistributeResponse response = SettleDistributeResponse.ofRandomSettle(splitAmounts);
+
+      // when
+      when(settlementServiceFinder.find(request.getSettlementType())).thenReturn(
+          randomSettlementService);
+      when(equalSettlementService.distribute(any())).thenReturn(response);
+
+      // then
+      mockMvc.perform(
+              post(URI + "/distribute")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isOk())
+          .andDo(print());
+    }
+  }
+
+  @Nested
+  @DisplayName("정산 요청")
+  class SettleMethod {
+
+    Long requesterId = 1L;
+    List<Long> participantsIds = List.of(1L, 2L);
+    long totalAmount = 1_000L;
+    long supportsAmount = 0;
+    long[] amounts = new long[]{500L, 500L};
+
+    @Test
+    @DisplayName("실패 - 요청자 ID가 null인 경우")
+    void settle_requesterId_null() throws Exception {
+      // given
+      SettleRequest request = new SettleRequest(
+          null, participantsIds, totalAmount, supportsAmount, amounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 참여자 수가 최소 요구사항보다 적은 경우")
+    void settle_participants_size_smaller_than_min() throws Exception {
+      // given
+      SettleRequest request = new SettleRequest(
+          requesterId, List.of(1L), totalAmount, supportsAmount, amounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 참여자 수가 최대 요구사항보다 큰 경우")
+    void settle_participants_size_bigger_than_max() throws Exception {
+      List<Long> oversizeParticipantIds = new ArrayList<>();
+      for (int i = 1; i <= SETTLEMENT_PARTICIPANTS_MAX_SIZE + 1; i++) {
+        oversizeParticipantIds.add((long) i);
+      }
+      // given
+      SettleRequest request = new SettleRequest(
+          requesterId, oversizeParticipantIds, totalAmount, supportsAmount, amounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 분배 금액 배열의 길이가 최소 요구사항보다 짧은 경우")
+    void settle_amounts_length_shorter_than_min() throws Exception {
+      // given
+      long[] shortAmounts = new long[SETTLEMENT_PARTICIPANTS_MIN_SIZE - 1];
+
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, shortAmounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 분배 금액 배열의 길이가 최대 요구사항보다 긴 경우")
+    void settle_amounts_length_longer_than_min() throws Exception {
+      // given
+      long[] longAmounts = new long[SETTLEMENT_PARTICIPANTS_MAX_SIZE + 1];
+
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, longAmounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 정산 요청 금액이 최소 참여자 수보다 작은 경우")
+    void settle_total_amount_smaller_than_participants_min_size() throws Exception {
+      // given
+      long smallTotalAmount = SETTLEMENT_PARTICIPANTS_MIN_SIZE - 1;
+
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, smallTotalAmount, supportsAmount, amounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 정산 타입이 null인 경우")
+    void settle_settle_type_is_null() throws Exception {
+      // given
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, amounts, null);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 참여자 수와 amounts 배열의 길이가 다를 경우")
+    void settle_participants_size_and_amounts_length_is_not_same() throws Exception {
+      // given
+      List<Long> twoParticipantIds = List.of(1L, 2L);
+      long[] threeLengthAmounts = new long[3];
+
+      SettleRequest request = new SettleRequest(
+          requesterId, twoParticipantIds, totalAmount, supportsAmount, threeLengthAmounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(INVALID_SETTLE_REQUEST.getMessage()))
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 참여자 수가 총 정산 금액보다 클 경우")
+    void settle_participants_size_bigger_than_total_amount() throws Exception {
+      // given
+      List<Long> fiveParticipantsIds = List.of(1L, 2L, 3L, 4L, 5L);
+      long[] amounts = new long[fiveParticipantsIds.size()];
+      long smallerTotalAmount = 4L;
+
+      SettleRequest request = new SettleRequest(
+          requesterId, fiveParticipantsIds, smallerTotalAmount, supportsAmount, amounts, EQUAL);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(INSUFFICIENT_SETTLE_AMOUNT.getMessage()))
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("실패 - 랜덤 정산 시, 총 정산 금액이 랜덤 정산의 최소 요구 금액보다 적은 경우")
+    void random_settle_total_amount_smaller_than_random_settlement_min_amount() throws Exception {
+      // given
+      long totalAmount = RANDOM_SETTLEMENT_MIN_AMOUNT - 1;
+
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, amounts, RANDOM);
+      // when
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value(INSUFFICIENT_SETTLE_AMOUNT.getMessage()))
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공 - 1/N 정산")
+    void settle_of_equal() throws Exception {
+      // given
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, amounts, EQUAL);
+
+      Long response = 1L;
+
+      // when
+      when(settlementServiceFinder.find(request.getSettlementType())).thenReturn(
+          equalSettlementService);
+      when(equalSettlementService.settle(any())).thenReturn(response);
+
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isCreated())
+          .andExpect(header().string("Location", URI + "/" + response))
+          .andDo(print());
+    }
+
+    @Test
+    @DisplayName("성공 - 랜덤 정산")
+    void settle_of_random() throws Exception {
+      // given
+      SettleRequest request = new SettleRequest(
+          requesterId, participantsIds, totalAmount, supportsAmount, amounts, RANDOM);
+
+      Long response = 1L;
+
+      // when
+      when(settlementServiceFinder.find(request.getSettlementType())).thenReturn(
+          randomSettlementService);
+      when(randomSettlementService.settle(any())).thenReturn(response);
+
+      // then
+      mockMvc.perform(
+              post(URI)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request))
+          ).andExpect(status().isCreated())
+          .andExpect(header().string("Location", URI + "/" + response))
+          .andDo(print());
+    }
+  }
+}

--- a/src/test/java/com/jindo/minipay/settlement/service/EqualSettlementServiceTest.java
+++ b/src/test/java/com/jindo/minipay/settlement/service/EqualSettlementServiceTest.java
@@ -1,0 +1,224 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.global.exception.ErrorCode.INVALID_PARTICIPANT;
+import static com.jindo.minipay.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.jindo.minipay.settlement.type.SettlementType.EQUAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.jindo.minipay.global.exception.CustomException;
+import com.jindo.minipay.member.entity.Member;
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.dto.SettleRequest;
+import com.jindo.minipay.settlement.entity.Settlement;
+import com.jindo.minipay.settlement.repository.ParticipantSettlementRepository;
+import com.jindo.minipay.settlement.repository.SettlementRepository;
+import com.jindo.minipay.settlement.type.SettlementType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EqualSettlementServiceTest {
+
+  @Mock
+  MemberRepository memberRepository;
+
+  @Mock
+  SettlementRepository settlementRepository;
+
+  @Mock
+  ParticipantSettlementRepository participantSettlementRepository;
+
+  @InjectMocks
+  EqualSettlementService settlementService;
+
+  @Test
+  @DisplayName("정산 타입을 리턴한다.")
+  void getType() {
+    SettlementType type = settlementService.getType();
+    assertThat(type).isEqualTo(EQUAL);
+  }
+
+  @Nested
+  @DisplayName("1/N 정산 금액 분배")
+  class EqualSettleDistributeMethod {
+
+    Long requesterId = 1L;
+
+    @Test
+    @DisplayName("성공 - 총 정산금액을 참여자 수로 나눈 몫으로 분배한다.")
+    void distribute() {
+      // given
+      int participantsSize = 3;
+      long totalAmount = 10_000L;
+
+      long splitAmount = totalAmount / participantsSize;
+      long[] amounts = new long[]{splitAmount, splitAmount, splitAmount};
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, EQUAL);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      // then
+      assertThat(response.getSplitAmounts()).isEqualTo(amounts);
+    }
+
+    @Test
+    @DisplayName("성공 - 총 정산금액이 참여자 수로 나누어 떨어지면 지원해주지 않는다.")
+    void distribute_mod_is_zero() {
+      // given
+      int participantsSize = 3;
+      long totalAmount = 9_999L;
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, EQUAL);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      // then
+      assertThat(response.getSupportsAmount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("성공 - 총 정산금액이 참여자 수로 나누어 떨어지지 않으면 부족한 만큼 지원해준다.")
+    void distribute_mod_is_non_zero() {
+      // given
+      int participantsSize = 3;
+      long totalAmount = 10_000L;
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, EQUAL);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      // then
+      assertThat(response.getSupportsAmount()).isEqualTo(1L);
+    }
+  }
+
+  @Nested
+  @DisplayName("1/N 정산 요청")
+  class EqualSettleMethod {
+
+    Long requesterId = 1L;
+    List<Long> participantsIds = List.of(1L, 2L, 3L);
+    long totalAmount = 10_000L;
+    long supportsAmount = 1L;
+    long[] amounts = new long[]{3_333L, 3_333L, 3_333L};
+
+    SettleRequest request = new SettleRequest(
+        requesterId, participantsIds, totalAmount, supportsAmount, amounts, EQUAL);
+
+    @Test
+    @DisplayName("실패 - 존재히지 않는 참여자인 경우")
+    void settle_not_exists_participant() {
+      // given
+      Member participant1 = Member.builder()
+          .id(1L)
+          .build();
+
+      Member participant2 = Member.builder()
+          .id(2L)
+          .build();
+
+      given(memberRepository.findByIdIn(request.getParticipantIds()))
+          .willReturn(List.of(participant1, participant2));
+
+      // when
+      // then
+      assertThatThrownBy(() -> settlementService.settle(request))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(INVALID_PARTICIPANT.getMessage());
+    }
+
+    @Test
+    @DisplayName("실패 - 존재히지 않는 요청자인 경우")
+    void settle_not_exists_requester() {
+      // given
+      Member participant1 = Member.builder()
+          .id(1L)
+          .build();
+
+      Member participant2 = Member.builder()
+          .id(2L)
+          .build();
+
+      Member participant3 = Member.builder()
+          .id(2L)
+          .build();
+
+      given(memberRepository.findByIdIn(request.getParticipantIds()))
+          .willReturn(List.of(participant1, participant2, participant3));
+
+      given(memberRepository.findById(request.getRequesterId())).willThrow(
+          new CustomException(MEMBER_NOT_FOUND));
+
+      // when
+      // then
+      assertThatThrownBy(() -> settlementService.settle(request))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(MEMBER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공")
+    void settle() {
+      // given
+      Member requester = Member.builder()
+          .id(1L)
+          .build();
+
+      Member participant1 = Member.builder()
+          .id(1L)
+          .build();
+
+      Member participant2 = Member.builder()
+          .id(2L)
+          .build();
+
+      Member participant3 = Member.builder()
+          .id(2L)
+          .build();
+
+      Settlement savedSettlement = Settlement.builder()
+          .requester(requester)
+          .totalAmount(request.getTotalAmount())
+          .supportsAmount(request.getSupportsAmount())
+          .settlementType(request.getSettlementType())
+          .build();
+
+      given(memberRepository.findByIdIn(request.getParticipantIds()))
+          .willReturn(List.of(participant1, participant2, participant3));
+
+      given(memberRepository.findById(request.getRequesterId()))
+          .willReturn(Optional.of(requester));
+
+      given(settlementRepository.save(any())).willReturn(savedSettlement);
+
+      // when
+      Long settleId = settlementService.settle(request);
+
+      // then
+      verify(settlementRepository).save(any());
+      verify(participantSettlementRepository, times(request.getAmounts().length)).save(any());
+      assertThat(settleId).isEqualTo(savedSettlement.getId());
+    }
+  }
+}

--- a/src/test/java/com/jindo/minipay/settlement/service/RandomSettlementServiceTest.java
+++ b/src/test/java/com/jindo/minipay/settlement/service/RandomSettlementServiceTest.java
@@ -1,0 +1,118 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.settlement.constant.SettlementConstants.*;
+import static com.jindo.minipay.settlement.type.SettlementType.RANDOM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jindo.minipay.member.repository.MemberRepository;
+import com.jindo.minipay.settlement.constant.SettlementConstants;
+import com.jindo.minipay.settlement.dto.SettleDistributeRequest;
+import com.jindo.minipay.settlement.dto.SettleDistributeResponse;
+import com.jindo.minipay.settlement.repository.ParticipantSettlementRepository;
+import com.jindo.minipay.settlement.repository.SettlementRepository;
+import com.jindo.minipay.settlement.type.SettlementType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RandomSettlementServiceTest {
+
+  @Mock
+  MemberRepository memberRepository;
+
+  @Mock
+  SettlementRepository settlementRepository;
+
+  @Mock
+  ParticipantSettlementRepository participantSettlementRepository;
+
+  @InjectMocks
+  RandomSettlementService settlementService;
+
+  @Test
+  @DisplayName("정산 타입을 리턴한다.")
+  void getType() {
+    SettlementType type = settlementService.getType();
+    assertThat(type).isEqualTo(RANDOM);
+  }
+
+  @Nested
+  @DisplayName("랜덤 정산 금액 분배")
+  class RandomSettleDistributeMethod {
+
+    Long requesterId = 1L;
+
+    @Test
+    @DisplayName("성공 - 총 정산금액을 랜덤으로 분배한다.")
+    void distribute() {
+      // given
+      int participantsSize = 3;
+      long totalAmount = 10_000L;
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, RANDOM);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      // then
+      assertThat(response.getSplitAmounts().length).isEqualTo(participantsSize);
+      assertThat(response.getSupportsAmount()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("성공 - 총 금액이 100으로 나누어 떨어지면, 분배금액또한 100으로 나누어떨어지는 수로 분배된다.")
+    void distribute_mod_is_zero() {
+      // given
+
+      int participantsSize = 3;
+      long totalAmount = 10_000L;
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, RANDOM);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      long[] splitAmounts = response.getSplitAmounts();
+
+      int correct = 0;
+      for (long splitAmount : splitAmounts) {
+        if (splitAmount % RANDOM_SETTLEMENT_UNIT == 0) {
+          correct++;
+        }
+      }
+      assertThat(correct).isEqualTo(splitAmounts.length);
+    }
+
+    @Test
+    @DisplayName("성공 - 총 금액이 100으로 나누어 떨어지지 않으면, 하나의 분배금액를 제외한 나머지는 100으로 나누어 떨어진다.")
+    void distribute_mod_is_non_zero() {
+      // given
+
+      int participantsSize = 3;
+      long totalAmount = 9_999L;
+
+      SettleDistributeRequest request = new SettleDistributeRequest(
+          requesterId, participantsSize, totalAmount, RANDOM);
+
+      // when
+      SettleDistributeResponse response = settlementService.distribute(request);
+
+      long[] splitAmounts = response.getSplitAmounts();
+
+      int correct = 0;
+      for (long splitAmount : splitAmounts) {
+        if (splitAmount % RANDOM_SETTLEMENT_UNIT == 0) {
+          correct++;
+        }
+      }
+      assertThat(correct).isEqualTo(splitAmounts.length - 1);
+    }
+  }
+}

--- a/src/test/java/com/jindo/minipay/settlement/service/SettlementServiceFinderTest.java
+++ b/src/test/java/com/jindo/minipay/settlement/service/SettlementServiceFinderTest.java
@@ -1,0 +1,68 @@
+package com.jindo.minipay.settlement.service;
+
+import static com.jindo.minipay.settlement.type.SettlementType.EQUAL;
+import static com.jindo.minipay.settlement.type.SettlementType.RANDOM;
+import static com.jindo.minipay.global.exception.ErrorCode.NOT_EXISTS_SETTLE_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jindo.minipay.settlement.type.SettlementType;
+import com.jindo.minipay.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SettlementServiceFinderTest {
+
+  @Autowired
+  SettlementServiceFinder settlementServiceFinder;
+
+  @Autowired
+  EqualSettlementService equalSettlementService;
+
+  @Autowired
+  RandomSettlementService randomSettlementService;
+
+  @Nested
+  @DisplayName("SettlementType에 따른 Service 찾기")
+  class FindSettleService {
+
+    @Test
+    @DisplayName("실패 - 타입이 유효하지 않은 경우 예외를 던진다.")
+    void if_settlement_type_is_invalid() {
+      // given
+      SettlementType settlementType = null;
+
+      // when
+      // then
+      assertThatThrownBy(() -> settlementServiceFinder.find(settlementType))
+          .isInstanceOf(CustomException.class)
+          .hasMessage(NOT_EXISTS_SETTLE_TYPE.getMessage());
+    }
+
+    @Test
+    @DisplayName("성공 - 타입이 EQUAL이면 EqualSettlementService를 찾는다.")
+    void if_settlement_type_is_equal_find_EqualSettlementService() {
+      // given
+      // when
+      SettlementService settlementService = settlementServiceFinder.find(EQUAL);
+
+      // then
+      assertThat(settlementService).isEqualTo(equalSettlementService);
+    }
+
+    @Test
+    @DisplayName("성공 - 타입이 RANDOM이면 RandomSettlementService를 찾는다.")
+    void if_settlement_type_is_equal_find_RandomSettlementService() {
+      // given
+      // when
+      SettlementService settlementService = settlementServiceFinder.find(RANDOM);
+
+      // then
+      assertThat(settlementService).isEqualTo(randomSettlementService);
+    }
+  }
+}


### PR DESCRIPTION
## 정산 API
- 정산 금액 분배 API와 정산 요청 API로 분리하였습니다.
- 정산의 참여자들이 생성된 정산마다 본인의 정산 현황을 확인할 수 있도록 엔티티를 설계하였습니다.

![스크린샷 2024-07-18 21 23 20](https://github.com/user-attachments/assets/fd2daaaa-95da-42eb-bd78-7ae7509a0e8e)
- 정산은 '1/N 정산'과 '랜덤 정산' 두 타입이 존재해서, `SettlementService` 추상 클래스를 부모 클래스로 생성하고,`EqualSettlementService`와 `RandomSettleService`를 해당 추상 클래스를 상속받도록 하여, 각각의 서비스로 구분해주었습니다.
- request로 넘어오는 정산 타입에 따라 매칭되는 서비스를 찾아줘야했기 때문에, `SettlementServiceFinder`를 구현하였습니다.

### 정산 금액 분배 API
- 정산 금액 분배 API는 요청자, 참여자 수, 총 금액, 정산 타입을 요청으로 받고 응답으로는 단순히 분배된 금액을 담고 있는 배열을 보냅니다.
- 참여자 수는 최소 2명에서 최대 50까지 가능하고, 정산 총 금액은 1원부터 500만원까지 가능합니다.

### 정산 요청 API
- `정산 금액 분배 API`를 통해 분배된 금액을 담고 있는 배열을 응답받게 되면, 응답 배열을 토대로 정산을 요청하게 됩니다.
- 실제로 정산을 요청하는 것이기 때문에, `settlement` 테이블에 insert를 해주고, 그와 동시에 `participant_settlement` 테이블에도 insert합니다.
- 정산 요청 서비스 로직은 정산의 타입과는 무관하기 때문에, `SettlementService`에서 공통으로 사용할 수 있도록 하였습니다.
- 응답으로는 생성된 정산의 id를 응답함으로써, 화면에서 바로 볼 수 있도록 하였습니다.

## 관련 이슈
close #4 